### PR TITLE
No-cookie youtube url

### DIFF
--- a/client/src/views/ProtubeScreen.vue
+++ b/client/src/views/ProtubeScreen.vue
@@ -91,7 +91,7 @@ onBeforeMount(() => {
 
 onMounted(() => {
   player = YoutubePlayer(playerID, {
-    host: "https://www.youtube.com",
+    host: "https://www.youtube-nocookie.com",
     videoId: "",
     playerVars: {
       autoplay: 1,


### PR DESCRIPTION
Use a no-cookie url from YouTube to load embeds without tracking cookies