### PR TITLE
Styling/css scrollbar

### DIFF
--- a/client/src/components/CurrentQueue.vue
+++ b/client/src/components/CurrentQueue.vue
@@ -12,7 +12,7 @@
       </button>
     </div>
     <div
-      class="scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-gray-900 flex max-h-[84vh] justify-center overflow-y-scroll overscroll-contain px-0">
+      class="scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-proto_background_gray dark:scrollbar-thumb-neutral-800 dark:scrollbar-track-proto_background_gray-dark flex max-h-[84vh] justify-center overflow-y-scroll overscroll-contain px-0">
       <div v-if="skeletonLoading" class="flex-nowrap">
         <ul
           v-for="index in 10"

--- a/client/src/components/RadioStations.vue
+++ b/client/src/components/RadioStations.vue
@@ -8,7 +8,7 @@
       class="ml-4 rounded-md border border-gray-400 bg-white pl-2 text-gray-700 placeholder-gray-500 outline-none focus:placeholder-gray-600"
       placeholder="Filter" />
     <div
-      class="scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-gray-900 flex overflow-x-scroll py-5">
+      class="scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-proto_background_gray dark:scrollbar-thumb-neutral-800 dark:scrollbar-track-proto_background_gray-dark flex overflow-x-scroll py-5">
       <div class="flex flex-nowrap">
         <template v-if="!skeletonLoading">
           <div

--- a/client/src/views/ProtubeScreen.vue
+++ b/client/src/views/ProtubeScreen.vue
@@ -35,11 +35,11 @@
   <div class="absolute bottom-0 mb-1 w-screen rounded-lg">
     <div class="flex justify-between">
       <div
-        class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 max-w-[12%] rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+        class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
         Queue: {{ queueDuration }}
       </div>
       <div
-        class="border-proto_blue dark:bg-proto_secondary_gray-dark mr-4 mb-1 max-w-[12%] rounded-lg border-r-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+        class="border-proto_blue dark:bg-proto_secondary_gray-dark mr-4 mb-1 rounded-lg border-r-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
         Visit www.protu.be!
       </div>
     </div>
@@ -58,7 +58,7 @@
             background-size: cover;
             background-position: center center;
           "
-          class="border-proto_blue group relative col-span-1 inline-block flex h-full w-full flex-1 overflow-hidden rounded-sm rounded-lg border-l-4 text-center shadow">
+          class="border-proto_blue group relative col-span-1 inline-block flex h-full w-full flex-1 overflow-hidden rounded-lg border-l-4 text-center shadow">
           <div
             :style="index === 0 ? `width:${queueProgress}%;` : 'width:0%'"
             class="absolute h-full bg-white opacity-70" />


### PR DESCRIPTION
- Fixed issue regarding the width of queue-duration label
- Improved scrollbar styling (added light mode)
<img width="1130" alt="Schermafbeelding 2022-12-14 om 22 03 52" src="https://user-images.githubusercontent.com/43108191/207713888-a91a448b-93f4-4224-83c0-08e165e24d47.png">
<img width="1060" alt="Schermafbeelding 2022-12-14 om 22 04 05" src="https://user-images.githubusercontent.com/43108191/207713902-ae4461e8-2918-4112-bdf1-a3391d467629.png">
