### PR TITLE
fixed screensocket not connecting

### DIFF
--- a/client/src/components/ReconnectionHandler.vue
+++ b/client/src/components/ReconnectionHandler.vue
@@ -49,7 +49,9 @@ props.socket.on("connect_error", async (err) => {
   }
 });
 
-props.socket.on("disconnect", () => {
+props.socket.on("disconnect", (reason) => {
+  // Don't try to reconnect on manual disconnects (called on OnBeforeUnmounts)
+  if (reason === "io client disconnect") return;
   message.value = "Lost connection, attempting to reconnect..";
   props.socket.connect();
 });


### PR DESCRIPTION
When going to the screen it sometimes wouldn't load (especially when you viewed the screen before). This was caused by the reconnectionHandler which tries to reconnect lost connections but did not have a check if the connection was triggered manually. So it would reconnect as soon as you left the screen (as then we manually disconnect the socket)