### PR TITLE
feature/random public photos shown on an empty queue

### DIFF
--- a/client/src/views/ProtubeScreen.vue
+++ b/client/src/views/ProtubeScreen.vue
@@ -24,9 +24,31 @@
         v-if="playerState.playerType === enums.TYPES.RADIO"
         :radio="playerState.radio"
         :volume="volume" />
-      <div v-else class="text-4xl dark:text-white">
-        Nothing currently in the queue...<br />
-        Visit protu.be to add some tunes!
+      <div v-else class="dark:text-white">
+        <div v-if="!photo.error">
+        <div class="w-full h-screen">
+          <img
+              :src=photo.url
+              class="object-cover w-full h-full rounded-lg border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-8 bg-white"
+              alt="Loading..."
+          />
+        </div>
+        <div class="absolute top-0 left-0 mt-1 rounded-lg text-zinc-400 text-xl">
+          <div class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+            Album: {{ photo.album_name }}<br>
+            Taken on: {{photo.date_taken}}
+          </div>
+        </div>
+          <div class="absolute bottom-0 left-0 mb-1 rounded-lg text-4xl font-bold">
+            <div class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+              The queue is empty! Visit ProTu.be to play some epic tunes!
+            </div>
+          </div>
+        </div>
+        <div v-else class="text-4xl dark:text-white">
+          Nothing currently in the queue...<br />
+          Visit protu.be to add some tunes!
+        </div>
       </div>
     </div>
     <div v-show="isPlayingVideo">
@@ -150,6 +172,12 @@ const playerState = ref({
   volume: 0,
 });
 
+const photo=ref({
+  url:'',
+  album_name:'',
+  date_taken:0
+});
+
 // Compute the queue with the currently playing video at the front
 const queueWithCurrent = computed(() => {
   let currentVideo = playerState.value.video;
@@ -241,6 +269,8 @@ socket.on("new-video-timestamp", async (newStamp) => {
 
 socket.on("queue-update", (newQueue) => {
   queue.value = newQueue.queue;
+  console.log(newQueue.photo);
+  photo.value=newQueue.photo;
 });
 </script>
 

--- a/client/src/views/ProtubeScreen.vue
+++ b/client/src/views/ProtubeScreen.vue
@@ -26,21 +26,24 @@
         :volume="volume" />
       <div v-else class="dark:text-white">
         <div v-if="!photo.error">
-        <div class="w-full h-screen">
-          <img
-              :src=photo.url
-              class="object-cover w-full h-full rounded-lg border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-8 bg-white"
-              alt="Loading..."
-          />
-        </div>
-        <div class="absolute top-0 left-0 mt-1 rounded-lg text-zinc-400 text-xl">
-          <div class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
-            Album: {{ photo.album_name }}<br>
-            Taken on: {{photo.date_taken}}
+          <div class="h-screen w-full">
+            <img
+              :src="photo.url"
+              class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 h-full w-full rounded-lg rounded-lg border-l-8 bg-white object-cover"
+              alt="Loading..." />
           </div>
-        </div>
-          <div class="absolute bottom-0 left-0 mb-1 rounded-lg text-4xl font-bold">
-            <div class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+          <div
+            class="absolute top-0 left-0 mt-1 rounded-lg text-xl text-zinc-400">
+            <div
+              class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+              Album: {{ photo.album_name }}<br />
+              Taken on: {{ photo.date_taken }}
+            </div>
+          </div>
+          <div
+            class="absolute bottom-0 left-0 mb-1 rounded-lg text-4xl font-bold">
+            <div
+              class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
               The queue is empty! Visit ProTu.be to play some epic tunes!
             </div>
           </div>
@@ -172,10 +175,10 @@ const playerState = ref({
   volume: 0,
 });
 
-const photo=ref({
-  url:'',
-  album_name:'',
-  date_taken:0
+const photo = ref({
+  url: "",
+  album_name: "",
+  date_taken: 0,
 });
 
 // Compute the queue with the currently playing video at the front
@@ -269,8 +272,7 @@ socket.on("new-video-timestamp", async (newStamp) => {
 
 socket.on("queue-update", (newQueue) => {
   queue.value = newQueue.queue;
-  console.log(newQueue.photo);
-  photo.value=newQueue.photo;
+  photo.value = newQueue.photo;
 });
 </script>
 

--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -1,16 +1,16 @@
 const endpoint = io.of("/socket/screen");
 const queueManager = require("../QueueManager");
 const playbackManager = require("../PlaybackManager");
-let newPhotoInterval=null;
-let photo=null;
+let newPhotoInterval = null;
+let photo = null;
 endpoint.on("connection", (socket) => {
   logger.screenInfo(
     `Screen connected from ${socket.handshake.address} with socket id ${socket.id}`
   );
 
-  if(!photo)emitNewPhoto()
+  if (!photo) emitNewPhoto();
   endpoint.emit("queue-update", {
-    queue:[],
+    queue: [],
     duration: "00:00:00",
     photo: photo,
   });
@@ -31,17 +31,17 @@ endpoint.on("connection", (socket) => {
 });
 
 eventBus.on("queue-update", () => {
-  let queue=queueManager.getQueue();
-  if(queue.length<=0) {
+  let queue = queueManager.getQueue();
+  if (queue.length <= 0) {
     emitNewPhoto();
-  }else {
+  } else {
     endpoint.emit("queue-update", {
       queue: queueManager.getQueue(),
       duration: queueManager.getTotalDurationFormatted(),
       photo: {},
     });
     clearInterval(newPhotoInterval);
-    newPhotoInterval=null;
+    newPhotoInterval = null;
   }
 });
 
@@ -62,15 +62,17 @@ eventBus.on("new-video-timestamp", (timestamp) => {
 });
 
 function emitNewPhoto() {
-  if(newPhotoInterval===null){
-    newPhotoInterval=setInterval(emitNewPhoto, 10000)
+  if (newPhotoInterval === null) {
+    newPhotoInterval = setInterval(emitNewPhoto, 10000);
   }
-  fetch(`${process.env.LARAVEL_ENDPOINT}/api/photos/random_photo`).then(res => res.json()).then((newPhoto) => {
-    photo=newPhoto;
-    endpoint.emit("queue-update", {
-      queue:[],
-      duration: "00:00:00",
-      photo: photo,
+  fetch(`${process.env.LARAVEL_ENDPOINT}/api/photos/random_photo`)
+    .then((res) => res.json())
+    .then((newPhoto) => {
+      photo = newPhoto;
+      endpoint.emit("queue-update", {
+        queue: [],
+        duration: "00:00:00",
+        photo: photo,
+      });
     });
-  })
 }

--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -1,3 +1,4 @@
+const fetch = require("node-fetch");
 const endpoint = io.of("/socket/screen");
 const queueManager = require("../QueueManager");
 const playbackManager = require("../PlaybackManager");

--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -1,15 +1,18 @@
 const endpoint = io.of("/socket/screen");
 const queueManager = require("../QueueManager");
 const playbackManager = require("../PlaybackManager");
-
+let newPhotoInterval=null;
+let photo=null;
 endpoint.on("connection", (socket) => {
   logger.screenInfo(
     `Screen connected from ${socket.handshake.address} with socket id ${socket.id}`
   );
 
-  socket.emit("queue-update", {
-    queue: queueManager.getQueue(),
-    duration: queueManager.getTotalDurationFormatted(),
+  if(!photo)emitNewPhoto()
+  endpoint.emit("queue-update", {
+    queue:[],
+    duration: "00:00:00",
+    photo: photo,
   });
 
   socket.on("disconnect", () => {
@@ -28,10 +31,18 @@ endpoint.on("connection", (socket) => {
 });
 
 eventBus.on("queue-update", () => {
-  endpoint.emit("queue-update", {
-    queue: queueManager.getQueue(),
-    duration: queueManager.getTotalDurationFormatted(),
-  });
+  let queue=queueManager.getQueue();
+  if(queue.length<=0) {
+    emitNewPhoto();
+  }else {
+    endpoint.emit("queue-update", {
+      queue: queueManager.getQueue(),
+      duration: queueManager.getTotalDurationFormatted(),
+      photo: {},
+    });
+    clearInterval(newPhotoInterval);
+    newPhotoInterval=null;
+  }
 });
 
 eventBus.on("player-update", () => {
@@ -49,3 +60,17 @@ eventBus.on("player-update", () => {
 eventBus.on("new-video-timestamp", (timestamp) => {
   endpoint.emit("new-video-timestamp", timestamp);
 });
+
+function emitNewPhoto() {
+  if(newPhotoInterval===null){
+    newPhotoInterval=setInterval(emitNewPhoto, 10000)
+  }
+  fetch(`${process.env.LARAVEL_ENDPOINT}/api/photos/random_photo`).then(res => res.json()).then((newPhoto) => {
+    photo=newPhoto;
+    endpoint.emit("queue-update", {
+      queue:[],
+      duration: "00:00:00",
+      photo: photo,
+    });
+  })
+}

--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -10,8 +10,8 @@ endpoint.on("connection", (socket) => {
 
   if (!photo) emitNewPhoto();
   endpoint.emit("queue-update", {
-    queue: [],
-    duration: "00:00:00",
+    queue: queueManager.getQueue(),
+    duration: queueManager.getTotalDurationFormatted(),
     photo: photo,
   });
 


### PR DESCRIPTION
Made the screens show public proto photos when the queue is empty.
Which photo gets displayed is chosen and synced through the server, but the fetching of the photo itself happens on client, so the screens show the same photo.
A new one gets chosen every 10 seconds with an setInterval.
When there is an error fetching the data on server or no photos are present it just shows the old 'no videos' screen.

Dependant on the laravel Feature/random public photo api endpoint (https://github.com/saproto/saproto/pull/1830) for the public API endpoint so do not merge this when that is not in master yet.
