### PR TITLE
Feature/show photos when playing radio

### DIFF
--- a/client/src/components/RadioScreen.vue
+++ b/client/src/components/RadioScreen.vue
@@ -1,12 +1,14 @@
 <template>
   <div class="z-50">
-    <div class="overflow-hidden relative w-[150px] h-[96px] rounded-lg text-white p-1">
+    <div
+      class="relative h-[96px] w-[150px] overflow-hidden rounded-lg p-1 text-white">
       <img
-          :alt="radio.o"
-          class="bg-proto_blue hover:bg-proto_blue/80 overflow-hidden rounded-lg truncate"
-          style="width: 150px"
-          :src="`https://www.nederland.fm/i/l/${radio.z}.gif`" />
-      <div class="absolute w-[200px] z-[-1] h-[200px] animate-[spin_3s_linear_infinite] h-full top-[-50%] left-[-25%] bg-gradient-to-r from-proto_blue via-[#ffffff] to-[#ffffff] "/>
+        :alt="radio.o"
+        class="bg-proto_blue hover:bg-proto_blue/80 overflow-hidden truncate rounded-lg"
+        style="width: 150px"
+        :src="`https://www.nederland.fm/i/l/${radio.z}.gif`" />
+      <div
+        class="from-proto_blue absolute top-[-50%] left-[-25%] z-[-1] h-[200px] h-full w-[200px] animate-[spin_3s_linear_infinite] bg-gradient-to-r via-[#ffffff] to-[#ffffff]" />
     </div>
     <br />
     <audio

--- a/client/src/components/RadioScreen.vue
+++ b/client/src/components/RadioScreen.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="z-50">
-    <img
-      :alt="radio.o"
-      class="bg-proto_blue hover:bg-proto_blue/80 overflow-hidden truncate rounded-lg text-white"
-      style="width: 150px"
-      :src="`https://www.nederland.fm/i/l/${radio.z}.gif`" />
+    <div class="overflow-hidden relative w-[150px] h-[96px] rounded-lg text-white p-1">
+      <img
+          :alt="radio.o"
+          class="bg-proto_blue hover:bg-proto_blue/80 overflow-hidden rounded-lg truncate"
+          style="width: 150px"
+          :src="`https://www.nederland.fm/i/l/${radio.z}.gif`" />
+      <div class="absolute w-[200px] z-[-1] h-[200px] animate-[spin_3s_linear_infinite] h-full top-[-50%] left-[-25%] bg-gradient-to-r from-proto_blue via-[#ffffff] to-[#ffffff] "/>
+    </div>
     <br />
     <audio
       id="radio"

--- a/client/src/components/RadioScreen.vue
+++ b/client/src/components/RadioScreen.vue
@@ -8,7 +8,7 @@
         style="width: 150px"
         :src="`https://www.nederland.fm/i/l/${radio.z}.gif`" />
       <div
-        class="from-proto_blue absolute top-[-50%] left-[-25%] z-[-1] h-[200px] h-full w-[200px] animate-[spin_3s_linear_infinite] bg-gradient-to-r via-[#ffffff] to-[#ffffff]" />
+        class="from-proto_blue absolute top-[-50%] left-[-25%] z-[-1] h-[200px] w-[200px] animate-[spin_3s_linear_infinite] bg-gradient-to-r via-white to-white" />
     </div>
     <br />
     <audio

--- a/client/src/components/VideoCard.vue
+++ b/client/src/components/VideoCard.vue
@@ -7,7 +7,7 @@
         background-size: cover;
         background-position: center center;
       "
-      :class="props.roundedCorners ? 'rounded-lg' : ''"
+      :class="(props.roundedCorners ? 'rounded-lg' : '')"
       class="border-proto_blue group col-span-1 flex w-full flex-col border-l-4 text-center shadow">
       <div
         :style="`width:${progressBar}%;`"

--- a/client/src/components/VideoCard.vue
+++ b/client/src/components/VideoCard.vue
@@ -7,7 +7,7 @@
         background-size: cover;
         background-position: center center;
       "
-      :class="(props.roundedCorners ? 'rounded-lg' : '')"
+      :class="props.roundedCorners ? 'rounded-lg' : ''"
       class="border-proto_blue group col-span-1 flex w-full flex-col border-l-4 text-center shadow">
       <div
         :style="`width:${progressBar}%;`"

--- a/client/src/views/ProtubeScreen.vue
+++ b/client/src/views/ProtubeScreen.vue
@@ -207,6 +207,10 @@ socket.on("new-video-timestamp", async (newStamp) => {
 
 socket.on("queue-update", (newQueue) => {
   queue.value = newQueue.queue;
-  photo.value = newQueue.photo;
+});
+
+socket.on("photo-update", (newPhoto) => {
+  photo.value = newPhoto;
+  console.log(newPhoto.url)
 });
 </script>

--- a/client/src/views/ProtubeScreen.vue
+++ b/client/src/views/ProtubeScreen.vue
@@ -24,25 +24,25 @@
       <div class="absolute bottom-0 mb-1 w-screen rounded-lg">
         <div class="flex justify-between">
           <div
-              class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+            class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
             Queue: {{ totalDuration }}
           </div>
         </div>
         <div class="mx-4 mb-1 grid grid-cols-5 gap-2 overflow-hidden">
           <VideoCard
-              v-for="(video, index) in queueWithCurrent.slice(0, 5)"
-              :key="video.id"
-              :index="index"
-              :title="video.title"
-              :name="video.user.name"
-              :channel="video.channel"
-              :duration="video.durationFormatted"
-              :thumbnail="video.thumbnail.url"
-              :videoID="video.id"
-              :textScrolling="true"
-              :roundedCorners="true"
-              :progressBar="index === 0 ? queueProgress : 0"
-              :opacity="0.9" />
+            v-for="(video, index) in queueWithCurrent.slice(0, 5)"
+            :key="video.id"
+            :index="index"
+            :title="video.title"
+            :name="video.user.name"
+            :channel="video.channel"
+            :duration="video.durationFormatted"
+            :thumbnail="video.thumbnail.url"
+            :videoID="video.id"
+            :textScrolling="true"
+            :roundedCorners="true"
+            :progressBar="index === 0 ? queueProgress : 0"
+            :opacity="0.9" />
         </div>
       </div>
     </div>
@@ -51,13 +51,13 @@
       <div v-if="photo && !photo.error && photo.url !== ''">
         <div class="flex h-screen justify-center overflow-x-hidden p-5">
           <img
-              :src="photo.url"
-              class="dark:bg-proto_secondary_gray-dark h-full max-w-none rounded-lg bg-white"
-              alt="Loading..." />
+            :src="photo.url"
+            class="dark:bg-proto_secondary_gray-dark h-full max-w-none rounded-lg bg-white"
+            alt="Loading..." />
         </div>
         <div class="absolute top-0 left-0 mt-2 ml-4 rounded-lg text-lg">
           <div
-              class="border-proto_blue dark:bg-proto_secondary_gray-dark rounded-lg border-l-4 bg-white p-1 px-4 py-2 text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+            class="border-proto_blue dark:bg-proto_secondary_gray-dark rounded-lg border-l-4 bg-white p-1 px-4 py-2 text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
             Album: {{ photo.album_name }}<br />
             Taken on: {{ photo.date_taken }}
           </div>
@@ -70,7 +70,14 @@
         </div>
       </div>
 
-      <div v-if="isPlayingRadio" class="" :class="(photo && !photo.error && photo.url !== '')?'place-items-end absolute right-0 bottom-0 mr-2':' grid h-screen place-items-center'">
+      <div
+        v-if="isPlayingRadio"
+        class=""
+        :class="
+          photo && !photo.error && photo.url !== ''
+            ? 'absolute right-0 bottom-0 mr-2 place-items-end'
+            : ' grid h-screen place-items-center'
+        ">
         <RadioScreen :radio="playerState.radio" :volume="volume" />
       </div>
     </div>
@@ -211,6 +218,6 @@ socket.on("queue-update", (newQueue) => {
 
 socket.on("photo-update", (newPhoto) => {
   photo.value = newPhoto;
-  console.log(newPhoto.url)
+  console.log(newPhoto.url);
 });
 </script>

--- a/client/src/views/ProtubeScreen.vue
+++ b/client/src/views/ProtubeScreen.vue
@@ -9,70 +9,73 @@
       </div>
     </div>
 
-    <div class="absolute top-0 right-0 mt-2">
-      <div
-        v-if="isPlayingVideo"
-        class="border-proto_blue dark:bg-proto_secondary_gray-dark mb-1 mr-4 mt-1 w-max rounded-lg border-r-4 bg-white px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
-        Want to add your own music? Visit www.protu.be!
+    <div v-show="isPlayingVideo">
+      <div :id="playerID" class="min-h-screen w-full" />
+    </div>
+
+    <div v-if="isPlayingVideo">
+      <div class="absolute top-0 right-0 mt-2">
+        <div
+          class="border-proto_blue dark:bg-proto_secondary_gray-dark mb-1 mr-4 mt-1 w-max rounded-lg border-r-4 bg-white px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+          Want to add your own music? Visit www.protu.be!
+        </div>
+      </div>
+
+      <div class="absolute bottom-0 mb-1 w-screen rounded-lg">
+        <div class="flex justify-between">
+          <div
+              class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+            Queue: {{ totalDuration }}
+          </div>
+        </div>
+        <div class="mx-4 mb-1 grid grid-cols-5 gap-2 overflow-hidden">
+          <VideoCard
+              v-for="(video, index) in queueWithCurrent.slice(0, 5)"
+              :key="video.id"
+              :index="index"
+              :title="video.title"
+              :name="video.user.name"
+              :channel="video.channel"
+              :duration="video.durationFormatted"
+              :thumbnail="video.thumbnail.url"
+              :videoID="video.id"
+              :textScrolling="true"
+              :roundedCorners="true"
+              :progressBar="index === 0 ? queueProgress : 0"
+              :opacity="0.9" />
+        </div>
       </div>
     </div>
 
-    <div v-if="isPlayingRadio" class="grid min-h-screen place-items-center">
-      <RadioScreen :radio="playerState.radio" :volume="volume" />
-    </div>
-
-    <div v-else-if="!isPlayingVideo" class="dark:text-white">
+    <div v-else class="dark:text-white">
       <div v-if="photo && !photo.error && photo.url !== ''">
         <div class="flex h-screen justify-center overflow-x-hidden p-5">
           <img
-            :src="photo.url"
-            class="dark:bg-proto_secondary_gray-dark h-full max-w-none rounded-lg bg-white"
-            alt="Loading..." />
+              :src="photo.url"
+              class="dark:bg-proto_secondary_gray-dark h-full max-w-none rounded-lg bg-white"
+              alt="Loading..." />
         </div>
         <div class="absolute top-0 left-0 mt-2 ml-4 rounded-lg text-lg">
           <div
-            class="border-proto_blue dark:bg-proto_secondary_gray-dark rounded-lg border-l-4 bg-white p-1 px-4 py-2 text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
+              class="border-proto_blue dark:bg-proto_secondary_gray-dark rounded-lg border-l-4 bg-white p-1 px-4 py-2 text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
             Album: {{ photo.album_name }}<br />
             Taken on: {{ photo.date_taken }}
           </div>
         </div>
       </div>
-      <div v-else class="grid h-screen place-items-center">
+      <div v-else-if="!isPlayingRadio" class="grid h-screen place-items-center">
         <div class="text-4xl dark:text-white">
           Nothing currently in the queue...<br />
           Visit protu.be to add some tunes!
         </div>
       </div>
-    </div>
 
-    <div v-show="isPlayingVideo">
-      <div :id="playerID" class="min-h-screen w-full" />
-    </div>
-  </div>
-  <div class="absolute bottom-0 mb-1 w-screen rounded-lg">
-    <div v-if="isPlayingVideo" class="flex justify-between">
-      <div
-        class="border-proto_blue dark:bg-proto_secondary_gray-dark ml-4 mb-1 rounded-lg border-l-4 bg-white p-1 px-4 py-2 font-medium text-gray-900 opacity-80 shadow-lg ring-1 ring-black ring-opacity-5 dark:text-gray-50">
-        Queue: {{ totalDuration }}
+      <div v-if="isPlayingRadio" class="" :class="(photo && !photo.error && photo.url !== '')?'place-items-end absolute right-0 bottom-0 mr-2':' grid h-screen place-items-center'">
+        <RadioScreen :radio="playerState.radio" :volume="volume" />
       </div>
     </div>
-    <div class="mx-4 mb-1 grid grid-cols-5 gap-2 overflow-hidden">
-      <VideoCard
-        v-for="(video, index) in queueWithCurrent.slice(0, 5)"
-        :key="video.id"
-        :index="index"
-        :title="video.title"
-        :name="video.user.name"
-        :channel="video.channel"
-        :duration="video.durationFormatted"
-        :thumbnail="video.thumbnail.url"
-        :videoID="video.id"
-        :textScrolling="true"
-        :roundedCorners="true"
-        :progressBar="index === 0 ? queueProgress : 0"
-        :opacity="0.9" />
-    </div>
   </div>
+
   <ReconnectionHandler
     v-if="screenCode === -1"
     :socket="socket"

--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -64,10 +64,19 @@ function emitNewPhoto() {
   if (newPhotoInterval === null) {
     newPhotoInterval = setInterval(emitNewPhoto, 10000);
   }
-  fetch(`${process.env.LARAVEL_ENDPOINT}/api/photos/random_photo`)
-    .then((res) => res.json())
-    .then((newPhoto) => {
-      photo = newPhoto;
-      endpoint.emit("photo-update", photo);
-    });
+  try {
+    fetch(`${process.env.LARAVEL_ENDPOINT}/api/photos/random_photo`)
+        .then((res) => res.json())
+        .then((newPhoto) => {
+          photo = newPhoto;
+          endpoint.emit("photo-update", photo);
+        });
+  }catch(e){
+      endpoint.emit("photo-update", {
+        url: "",
+        album_name: "",
+        date_taken: 0,
+        error: e,
+      });
+  }
 }

--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -4,17 +4,14 @@ const queueManager = require("../QueueManager");
 const playbackManager = require("../PlaybackManager");
 let newPhotoInterval = null;
 let photo = null;
+
 endpoint.on("connection", (socket) => {
   logger.screenInfo(
     `Screen connected from ${socket.handshake.address} with socket id ${socket.id}`
   );
 
   if (!photo) emitNewPhoto();
-  endpoint.emit("queue-update", {
-    queue: queueManager.getQueue(),
-    duration: queueManager.getTotalDurationFormatted(),
-    photo: photo,
-  });
+  socket.emit("photo-update", photo);
 
   socket.on("disconnect", () => {
     logger.screenInfo(`Disconnected socket: ${socket.id}`);
@@ -32,27 +29,28 @@ endpoint.on("connection", (socket) => {
 });
 
 eventBus.on("queue-update", () => {
-  let queue = queueManager.getQueue();
-  if (queue.length <= 0) {
-    emitNewPhoto();
-  } else {
     endpoint.emit("queue-update", {
       queue: queueManager.getQueue(),
       duration: queueManager.getTotalDurationFormatted(),
-      photo: {},
     });
-    clearInterval(newPhotoInterval);
-    newPhotoInterval = null;
-  }
 });
 
 eventBus.on("player-update", () => {
+  let queue = queueManager.getQueue();
+  let playerType = playbackManager.getPlayerType();
+  if (queue.length <= 0 || playerType!==enums.TYPES.VIDEO) {
+    emitNewPhoto();
+  }else if(playerType===enums.TYPES.VIDEO){
+    clearInterval(newPhotoInterval);
+    newPhotoInterval = null;
+  }
+
   endpoint.emit("player-update", {
-    playerType: playbackManager.getPlayerType(),
+    playerType: playerType,
     playerMode: playbackManager.getPlayerMode(),
     timestamp: playbackManager.getCurrentVideoTimestamp(),
     video: queueManager.getCurrentVideo(),
-    queue: queueManager.getQueue(),
+    queue: queue,
     volume: playbackManager.getVolume(),
     radio: playbackManager.getLastStation(),
   });
@@ -70,10 +68,6 @@ function emitNewPhoto() {
     .then((res) => res.json())
     .then((newPhoto) => {
       photo = newPhoto;
-      endpoint.emit("queue-update", {
-        queue: [],
-        duration: "00:00:00",
-        photo: photo,
-      });
+      endpoint.emit("photo-update", photo);
     });
 }

--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -29,18 +29,18 @@ endpoint.on("connection", (socket) => {
 });
 
 eventBus.on("queue-update", () => {
-    endpoint.emit("queue-update", {
-      queue: queueManager.getQueue(),
-      duration: queueManager.getTotalDurationFormatted(),
-    });
+  endpoint.emit("queue-update", {
+    queue: queueManager.getQueue(),
+    duration: queueManager.getTotalDurationFormatted(),
+  });
 });
 
 eventBus.on("player-update", () => {
   let queue = queueManager.getQueue();
   let playerType = playbackManager.getPlayerType();
-  if (queue.length <= 0 || playerType!==enums.TYPES.VIDEO) {
+  if (queue.length <= 0 || playerType !== enums.TYPES.VIDEO) {
     emitNewPhoto();
-  }else if(playerType===enums.TYPES.VIDEO){
+  } else if (playerType === enums.TYPES.VIDEO) {
     clearInterval(newPhotoInterval);
     newPhotoInterval = null;
   }
@@ -66,17 +66,17 @@ function emitNewPhoto() {
   }
   try {
     fetch(`${process.env.LARAVEL_ENDPOINT}/api/photos/random_photo`)
-        .then((res) => res.json())
-        .then((newPhoto) => {
-          photo = newPhoto;
-          endpoint.emit("photo-update", photo);
-        });
-  }catch(e){
-      endpoint.emit("photo-update", {
-        url: "",
-        album_name: "",
-        date_taken: 0,
-        error: e,
+      .then((res) => res.json())
+      .then((newPhoto) => {
+        photo = newPhoto;
+        endpoint.emit("photo-update", photo);
       });
+  } catch (e) {
+    endpoint.emit("photo-update", {
+      url: "",
+      album_name: "",
+      date_taken: 0,
+      error: e,
+    });
   }
 }


### PR DESCRIPTION
When the radio plays now the photos from the proto site will still be shown, and the radio icon moves to the bottom-right. That now has a nice animated border to still draw attention to it. Also, the photo update is now separate from the queue update so it still happens when the radio is playing.