### PR TITLE
Fixed the queue not showing on initial load.

### DIFF
--- a/server/modules/socket_endpoints/ScreenSocket.js
+++ b/server/modules/socket_endpoints/ScreenSocket.js
@@ -13,6 +13,11 @@ endpoint.on("connection", (socket) => {
   if (!photo) emitNewPhoto();
   socket.emit("photo-update", photo);
 
+  socket.emit("queue-update", {
+    queue: queueManager.getQueue(),
+    duration: queueManager.getTotalDurationFormatted(),
+  });
+
   socket.on("disconnect", () => {
     logger.screenInfo(`Disconnected socket: ${socket.id}`);
   });


### PR DESCRIPTION
send a queue update when a new screen connects so the screen immediately displays the queue, and it does not have to wait on a queue update. Fixes #98.