### PR TITLE
Allow gateway ip to admin screen

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -74,4 +74,4 @@ DATABASE_PORT=3636
 DATABASE_QUERY_LOGGING=true
 
 # Ip of the local client on which to always accept admin remotes
-LOCAL_CLIENT_IP=::ffff:127.0.0.1
+LOCAL_CLIENT_IP_CHECK=true

--- a/server/modules/Middlewares.js
+++ b/server/modules/Middlewares.js
@@ -13,12 +13,12 @@ const sessionStore = new SequelizeStore({ db: sequelize, table: "sessions" });
 // originate from the nginx container
 const allowLocalAdminConnections = process.env.LOCAL_CLIENT_IP_CHECK === "true";
 // Get the current gateway ip of the docker container,
-let gatewayIP = execSync("ip route | awk '/default/ {print $3}'", {
+const gatewayIP = execSync("ip route | awk '/default/ {print $3}'", {
   shell: true,
 })
   .toString()
   .trimEnd();
-let allowedIP = `::ffff:${gatewayIP}`;
+const allowedIP = `::ffff:${gatewayIP}`;
 
 exports.sessionMiddleware = session({
   secret: process.env.SESSION_SECRET,

--- a/server/modules/Middlewares.js
+++ b/server/modules/Middlewares.js
@@ -3,7 +3,7 @@ const { sequelize } = require("./DataBase");
 const SequelizeStore = require("connect-session-sequelize")(session.Store);
 const { getCurrentUnix } = require("../utils/time-formatter");
 const { checkScreenCode } = require("./ScreenCode");
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
 const moment = require("moment");
 require("passport");
 
@@ -12,8 +12,12 @@ const sessionStore = new SequelizeStore({ db: sequelize, table: "sessions" });
 // Connections that come from x.x.x.x:3000 go through the gateway but those from ngingx
 // originate from the nginx container
 const allowLocalAdminConnections = process.env.LOCAL_CLIENT_IP_CHECK === "true";
-// Get the current gateway ip of the docker container, 
-let gatewayIP = execSync("ip route | awk '/default/ {print $3}'", { shell: true }).toString().trimEnd();
+// Get the current gateway ip of the docker container,
+let gatewayIP = execSync("ip route | awk '/default/ {print $3}'", {
+  shell: true,
+})
+  .toString()
+  .trimEnd();
 let allowedIP = `::ffff:${gatewayIP}`;
 
 exports.sessionMiddleware = session({


### PR DESCRIPTION
The current ip for local screens in the .env doesn't work anymore because docker's internal ips can change. 
Connections that come through the localhost:3000 go through the gateway (ip x.x.x.1) and those through the proxy come from a different ip (x.x.x.3 e.g.).
This code fetches the gateway ip of the current protube container and then starts allowing that. It has not been fully tested but the command for the gateway ip is tested on an alpine container.

Note: 
- .env needs an update on production 
- hydra needs to use localhost:3000
- [ufw-docker](https://github.com/chaifeng/ufw-docker) (already installed via administator) needs to be enabled to only allow 80/443 (docker bypasses ufw iptables by default)

![Schermafbeelding 2023-03-15 om 10 15 17](https://user-images.githubusercontent.com/43108191/225262624-28150470-1bd3-42ee-88cc-0323d822662a.png)
